### PR TITLE
allow codeblocks to optionally collapse+expand or be scrollable

### DIFF
--- a/MARKDOWN.md
+++ b/MARKDOWN.md
@@ -43,6 +43,32 @@ In practice it makes a nice table:
 
 ## Our additions
 
+### Fences
+
+Using code blocks like normal work as you expect. However, we also have the following:
+
+#### Copy icons
+
+````
+```hoon {% copy=true %}
+````
+
+Adds a copy icon top right, that copies the buffer to clipboard.
+
+#### Collapsed or scroll appearances
+
+````
+```hoon {% mode="collapse" %}
+````
+
+Will collapse the code block to a set height and require a click to expand.
+
+````
+```hoon {% mode="scroll" %}
+````
+
+Will set the code block to a set height and allow the user to scroll.
+
 ### Superscript
 
 Pandoc style.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Our Markdown parser is a custom patched installation of Markdoc for additional f
 Import the component:
 
 ```js
-import Markdown from 'foundation-design-system/markdown'; 
+import Markdown from 'foundation-design-system'; 
 ```
 
 Then, on the server-side parse your content by passing it an object in the following shape:

--- a/examples/lib/codeblock.md
+++ b/examples/lib/codeblock.md
@@ -1,4 +1,4 @@
-```hoon {% copy=true %}
+```hoon {% copy=true mode="collapse" %}
 :-  %say
 |=  *
 :-  %noun

--- a/src/components/markdown/Fence.js
+++ b/src/components/markdown/Fence.js
@@ -1,4 +1,5 @@
 import React from "react";
+import classNames from "classnames";
 import { useCopyToClipboard } from "../../lib/hooks";
 import Copy from "../../lib/icons/copy";
 import Highlight, { defaultProps } from "prism-react-renderer";
@@ -6,10 +7,31 @@ import Prism from "prism-react-renderer/prism";
 (typeof global !== "undefined" ? global : window).Prism = Prism;
 require("prismjs/components/prism-hoon");
 
-export default function Fence({ children, language, copy = false }) {
+export default function Fence({
+  children,
+  language,
+  copy = false,
+  mode = "full",
+}) {
   const [copyStatus, useCopy] = useCopyToClipboard(children);
+  const [collapsed, setCollapse] = React.useState(Boolean(mode === "collapse"));
   return (
-    <div className="relative">
+    <div
+      className={classNames("relative rounded-xl", {
+        "max-h-60 overflow-hidden": collapsed,
+      })}
+    >
+      {collapsed && (
+        <>
+          <div className="absolute w-full h-44 bottom-0 overflow-hidden bg-gradient-to-b from-[rgb(255,255,255,0)] to-white z-10 rounded-xl opacity-80"></div>
+          <div
+            className="absolute w-full h-full flex justify-center items-end z-20 cursor-pointer"
+            onClick={() => setCollapse(false)}
+          >
+            <p className="!text-sm !font-semibold">Click to expand</p>
+          </div>
+        </>
+      )}
       {copy && (
         <div
           className="absolute flex items-center justify-center top-4 right-5 z-10 cursor-pointer !p-2 border rounded-xl border-[#afaeab]"
@@ -45,7 +67,12 @@ export default function Fence({ children, language, copy = false }) {
         theme={undefined}
       >
         {({ className, style, tokens, getLineProps, getTokenProps }) => (
-          <pre className={className} style={style}>
+          <pre
+            className={classNames(className, {
+              "max-h-96 overflow-y-auto": Boolean(mode === "scroll"),
+            })}
+            style={style}
+          >
             {tokens.slice(0, -1).map((line, i) => (
               <div {...getLineProps({ line, key: i })}>
                 {line.map((token, key) => (

--- a/src/schema/fence.markdoc.js
+++ b/src/schema/fence.markdoc.js
@@ -10,5 +10,10 @@ export const fence = {
       type: Boolean,
       description: "Adds a copy button.",
     },
+    mode: {
+      type: String,
+      description:
+        "Sets modes for code blocks. Specify either 'collapse' or 'scroll'.",
+    },
   },
 };


### PR DESCRIPTION
<img width="1019" alt="image" src="https://user-images.githubusercontent.com/20846414/178820229-93dd50a0-a1ef-44c9-b099-4d0f9c6c632e.png">

Adds a `mode` attribute. `mode="collapse"` collapses the code block with a fade you expand. `mode="scroll"` sets the max-height and lets the user scroll.

Fixes #6 