### PR TITLE
markdown: add mathjax support

### DIFF
--- a/MARKDOWN.md
+++ b/MARKDOWN.md
@@ -43,6 +43,80 @@ In practice it makes a nice table:
 
 ## Our additions
 
+### Math
+
+We use MathJax to render equations when creating technical documentation. Before using this component, note that the Next.js build will have to accomodate its quirks.
+
+Create a `_document.js` file and add its scripts:
+
+```js
+import { Html, Head, Main, NextScript } from 'next/document'
+import Script from 'next/script';
+
+export default function Document() {
+  return (
+    <Html>
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+        <Script strategy="beforeInteractive" dangerouslySetInnerHTML={{
+          __html: `window.__MathJax_State__ = {
+          isReady: false,
+          promise: new Promise(resolve => {
+
+            window.MathJax = {
+              loader: {load: ['[tex]/autoload', '[tex]/ams']},
+              tex: {
+                packages: {'[+]': ['autoload', 'ams']},
+                processEscapes: true
+              },
+              jax: ["input/TeX","output/CommonHTML"],
+              options: {
+                renderActions: {
+                  addMenu: []
+                }
+              },
+              startup: {
+                typeset: false,
+                ready: () => {
+                  MathJax.startup.defaultReady();
+                  window.__MathJax_State__.isReady = true;
+                  resolve();
+                }
+              }
+            };
+          })
+        };`}}
+        />
+        <Script strategy="beforeInteractive" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" />
+      </body>
+    </Html>
+  )
+}
+```
+
+Ensure your calls to Markdown use `String.raw()` so that you preserve backslashes, like this:
+
+```js
+const markdown = JSON.stringify(Markdown.parse({ post: { content: String.raw`${content}` } }));
+```
+
+Once both of these are in place, you can use the `{% math %}` block, setting it to `block=true` or `block=false` as necessary (for displayed math vs. inline math, respectively).
+
+```
+[Piecewise mathematical functions](https://en.wikipedia.org/wiki/Piecewise) require precisely this functionality.  For instance, the Heaviside function is a piecewise mathematical function which is equal to zero for inputs less than zero and one for inputs greater than or equal to zero.
+
+{% math block=true %}
+H(x)
+=
+\begin{cases} 1, & x > 0 \\\ 0, & x \le 0 \end{cases}
+{% /math %}
+```
+
+![](https://media.urbit.org/foundation/design/math.png)
+
+
 ### Fences
 
 Using code blocks like normal work as you expect. However, we also have the following:

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -31,7 +31,7 @@
     },
     "..": {
       "name": "@urbit/foundation-design-system",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
@@ -39,8 +39,6 @@
         "gray-matter": "^4.0.3",
         "html-react-parser": "^1.4.14",
         "luxon": "^3.0.1",
-        "mathjax-full": "^3.2.2",
-        "mathjax-react": "^2.0.1",
         "prism-react-renderer": "^1.3.3"
       },
       "devDependencies": {
@@ -4334,8 +4332,6 @@
         "gray-matter": "^4.0.3",
         "html-react-parser": "^1.4.14",
         "luxon": "^3.0.1",
-        "mathjax-full": "^3.2.2",
-        "mathjax-react": "^2.0.1",
         "prism-react-renderer": "^1.3.3",
         "rollup": "^2.75.7",
         "rollup-plugin-peer-deps-external": "^2.2.4"

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -31,11 +31,16 @@
     },
     "..": {
       "name": "@urbit/foundation-design-system",
-      "version": "0.3.1",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
+        "@iarna/toml": "^2.2.5",
         "core-js": "^3.23.1",
+        "gray-matter": "^4.0.3",
         "html-react-parser": "^1.4.14",
+        "luxon": "^3.0.1",
+        "mathjax-full": "^3.2.2",
+        "mathjax-react": "^2.0.1",
         "prism-react-renderer": "^1.3.3"
       },
       "devDependencies": {
@@ -4321,11 +4326,16 @@
       "version": "file:..",
       "requires": {
         "@babel/preset-react": "^7.17.12",
+        "@iarna/toml": "^2.2.5",
         "@rollup/plugin-babel": "^5.3.1",
         "@rollup/plugin-commonjs": "^22.0.0",
         "@rollup/plugin-node-resolve": "^13.3.0",
         "core-js": "^3.23.1",
+        "gray-matter": "^4.0.3",
         "html-react-parser": "^1.4.14",
+        "luxon": "^3.0.1",
+        "mathjax-full": "^3.2.2",
+        "mathjax-react": "^2.0.1",
         "prism-react-renderer": "^1.3.3",
         "rollup": "^2.75.7",
         "rollup-plugin-peer-deps-external": "^2.2.4"

--- a/examples/pages/components/markdown/math.js
+++ b/examples/pages/components/markdown/math.js
@@ -1,0 +1,27 @@
+import Container from "../../../../src/components/layout/Container";
+import Section from "../../../../src/components/layout/Section";
+import SingleColumn from "../../../../src/components/layout/SingleColumn";
+import Markdown from "../../../../src/components/Markdown";
+export default function IntraNavPage({ markdown }) {
+    return (
+        <Container>
+            <SingleColumn>
+                <Section className="markdown">
+                    <h2>Math</h2>
+                    <Markdown.render content={JSON.parse(markdown)} />
+                </Section>
+            </SingleColumn>
+        </Container>
+    );
+}
+
+export async function getStaticProps({ params }) {
+    const markdown = JSON.stringify(
+        Markdown.parse({
+            post: {
+                content: String.raw`{% math %}\sum_{2}^{\longrightarrow \beta}\equiv \beta\beta\beta\beta{% /math %}`,
+            },
+        })
+    );
+    return { props: { markdown } };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urbit/foundation-design-system",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@urbit/foundation-design-system",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
@@ -14,6 +14,8 @@
         "gray-matter": "^4.0.3",
         "html-react-parser": "^1.4.14",
         "luxon": "^3.0.1",
+        "mathjax-full": "^3.2.2",
+        "mathjax-react": "^2.0.1",
         "prism-react-renderer": "^1.3.3"
       },
       "devDependencies": {
@@ -1065,6 +1067,14 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "peer": true
     },
+    "node_modules/commander": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1264,6 +1274,14 @@
       "peer": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/esprima": {
@@ -1717,6 +1735,35 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
+    "node_modules/mathjax-full": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.2.tgz",
+      "integrity": "sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==",
+      "dependencies": {
+        "esm": "^3.2.25",
+        "mhchemparser": "^4.1.0",
+        "mj-context-menu": "^0.6.1",
+        "speech-rule-engine": "^4.0.6"
+      }
+    },
+    "node_modules/mathjax-react": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mathjax-react/-/mathjax-react-2.0.1.tgz",
+      "integrity": "sha512-bEDPfGTm8Bi4VylmFbg5SGCN/BzDCiTJMTXDalAFDnsTwAhDdJgBRWlO5nHRtj+3/bOSfYF7wak7qmRN6XbPOw==",
+      "dependencies": {
+        "mathjax-full": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "mathjax-full": "^3.0.4",
+        "prop-types": "^15.5.4",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1725,6 +1772,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/mhchemparser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.1.1.tgz",
+      "integrity": "sha512-R75CUN6O6e1t8bgailrF1qPq+HhVeFTM3XQ0uzI+mXTybmphy3b6h4NbLOYhemViQ3lUs+6CKRkC3Ws1TlYREA=="
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
@@ -1756,6 +1808,11 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "peer": true
+    },
+    "node_modules/mj-context-menu": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
+      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -2064,6 +2121,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2122,6 +2190,12 @@
       "peerDependencies": {
         "react": "17.0.2"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "peer": true
     },
     "node_modules/react-property": {
       "version": "2.0.0",
@@ -2284,6 +2358,19 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
+    },
+    "node_modules/speech-rule-engine": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.0.7.tgz",
+      "integrity": "sha512-sJrL3/wHzNwJRLBdf6CjJWIlxC04iYKkyXvYSVsWVOiC2DSkHmxsqOhEeMsBA9XK+CHuNcsdkbFDnoUfAsmp9g==",
+      "dependencies": {
+        "commander": "9.2.0",
+        "wicked-good-xpath": "1.3.0",
+        "xmldom-sre": "0.1.31"
+      },
+      "bin": {
+        "sre": "bin/sre"
+      }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -2483,11 +2570,24 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "peer": true
     },
+    "node_modules/wicked-good-xpath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
+      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw=="
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/xmldom-sre": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/xmldom-sre/-/xmldom-sre-0.1.31.tgz",
+      "integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw==",
+      "engines": {
+        "node": ">=0.1"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -3262,6 +3362,11 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "commander": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w=="
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -3403,6 +3508,11 @@
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "peer": true
+    },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
     },
     "esprima": {
       "version": "4.0.1",
@@ -3739,11 +3849,35 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
+    "mathjax-full": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.2.tgz",
+      "integrity": "sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==",
+      "requires": {
+        "esm": "^3.2.25",
+        "mhchemparser": "^4.1.0",
+        "mj-context-menu": "^0.6.1",
+        "speech-rule-engine": "^4.0.6"
+      }
+    },
+    "mathjax-react": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mathjax-react/-/mathjax-react-2.0.1.tgz",
+      "integrity": "sha512-bEDPfGTm8Bi4VylmFbg5SGCN/BzDCiTJMTXDalAFDnsTwAhDdJgBRWlO5nHRtj+3/bOSfYF7wak7qmRN6XbPOw==",
+      "requires": {
+        "mathjax-full": "^3.0.4"
+      }
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "peer": true
+    },
+    "mhchemparser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.1.1.tgz",
+      "integrity": "sha512-R75CUN6O6e1t8bgailrF1qPq+HhVeFTM3XQ0uzI+mXTybmphy3b6h4NbLOYhemViQ3lUs+6CKRkC3Ws1TlYREA=="
     },
     "micromatch": {
       "version": "4.0.5",
@@ -3769,6 +3903,11 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "peer": true
+    },
+    "mj-context-menu": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
+      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="
     },
     "ms": {
       "version": "2.1.2",
@@ -3955,6 +4094,17 @@
       "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==",
       "peer": true
     },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "peer": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -3987,6 +4137,12 @@
         "object-assign": "^4.1.1",
         "scheduler": "^0.20.2"
       }
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "peer": true
     },
     "react-property": {
       "version": "2.0.0",
@@ -4105,6 +4261,16 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
+    },
+    "speech-rule-engine": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.0.7.tgz",
+      "integrity": "sha512-sJrL3/wHzNwJRLBdf6CjJWIlxC04iYKkyXvYSVsWVOiC2DSkHmxsqOhEeMsBA9XK+CHuNcsdkbFDnoUfAsmp9g==",
+      "requires": {
+        "commander": "9.2.0",
+        "wicked-good-xpath": "1.3.0",
+        "xmldom-sre": "0.1.31"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -4247,11 +4413,21 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "peer": true
     },
+    "wicked-good-xpath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
+      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw=="
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "xmldom-sre": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/xmldom-sre/-/xmldom-sre-0.1.31.tgz",
+      "integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,6 @@
         "gray-matter": "^4.0.3",
         "html-react-parser": "^1.4.14",
         "luxon": "^3.0.1",
-        "mathjax-full": "^3.2.2",
-        "mathjax-react": "^2.0.1",
         "prism-react-renderer": "^1.3.3"
       },
       "devDependencies": {
@@ -1067,14 +1065,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "peer": true
     },
-    "node_modules/commander": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
-      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1274,14 +1264,6 @@
       "peer": true,
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/esprima": {
@@ -1735,35 +1717,6 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
-    "node_modules/mathjax-full": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.2.tgz",
-      "integrity": "sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==",
-      "dependencies": {
-        "esm": "^3.2.25",
-        "mhchemparser": "^4.1.0",
-        "mj-context-menu": "^0.6.1",
-        "speech-rule-engine": "^4.0.6"
-      }
-    },
-    "node_modules/mathjax-react": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mathjax-react/-/mathjax-react-2.0.1.tgz",
-      "integrity": "sha512-bEDPfGTm8Bi4VylmFbg5SGCN/BzDCiTJMTXDalAFDnsTwAhDdJgBRWlO5nHRtj+3/bOSfYF7wak7qmRN6XbPOw==",
-      "dependencies": {
-        "mathjax-full": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      },
-      "peerDependencies": {
-        "mathjax-full": "^3.0.4",
-        "prop-types": "^15.5.4",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1772,11 +1725,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/mhchemparser": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.1.1.tgz",
-      "integrity": "sha512-R75CUN6O6e1t8bgailrF1qPq+HhVeFTM3XQ0uzI+mXTybmphy3b6h4NbLOYhemViQ3lUs+6CKRkC3Ws1TlYREA=="
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
@@ -1808,11 +1756,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "peer": true
-    },
-    "node_modules/mj-context-menu": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
-      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -2121,17 +2064,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2190,12 +2122,6 @@
       "peerDependencies": {
         "react": "17.0.2"
       }
-    },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "peer": true
     },
     "node_modules/react-property": {
       "version": "2.0.0",
@@ -2358,19 +2284,6 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
-    },
-    "node_modules/speech-rule-engine": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.0.7.tgz",
-      "integrity": "sha512-sJrL3/wHzNwJRLBdf6CjJWIlxC04iYKkyXvYSVsWVOiC2DSkHmxsqOhEeMsBA9XK+CHuNcsdkbFDnoUfAsmp9g==",
-      "dependencies": {
-        "commander": "9.2.0",
-        "wicked-good-xpath": "1.3.0",
-        "xmldom-sre": "0.1.31"
-      },
-      "bin": {
-        "sre": "bin/sre"
-      }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -2570,24 +2483,11 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "peer": true
     },
-    "node_modules/wicked-good-xpath": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
-      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw=="
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
-    },
-    "node_modules/xmldom-sre": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom-sre/-/xmldom-sre-0.1.31.tgz",
-      "integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw==",
-      "engines": {
-        "node": ">=0.1"
-      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -3362,11 +3262,6 @@
         "simple-swizzle": "^0.2.2"
       }
     },
-    "commander": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
-      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w=="
-    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -3508,11 +3403,6 @@
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "peer": true
-    },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
     },
     "esprima": {
       "version": "4.0.1",
@@ -3849,35 +3739,11 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
-    "mathjax-full": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.2.tgz",
-      "integrity": "sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==",
-      "requires": {
-        "esm": "^3.2.25",
-        "mhchemparser": "^4.1.0",
-        "mj-context-menu": "^0.6.1",
-        "speech-rule-engine": "^4.0.6"
-      }
-    },
-    "mathjax-react": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mathjax-react/-/mathjax-react-2.0.1.tgz",
-      "integrity": "sha512-bEDPfGTm8Bi4VylmFbg5SGCN/BzDCiTJMTXDalAFDnsTwAhDdJgBRWlO5nHRtj+3/bOSfYF7wak7qmRN6XbPOw==",
-      "requires": {
-        "mathjax-full": "^3.0.4"
-      }
-    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "peer": true
-    },
-    "mhchemparser": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.1.1.tgz",
-      "integrity": "sha512-R75CUN6O6e1t8bgailrF1qPq+HhVeFTM3XQ0uzI+mXTybmphy3b6h4NbLOYhemViQ3lUs+6CKRkC3Ws1TlYREA=="
     },
     "micromatch": {
       "version": "4.0.5",
@@ -3903,11 +3769,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "peer": true
-    },
-    "mj-context-menu": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
-      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="
     },
     "ms": {
       "version": "2.1.2",
@@ -4094,17 +3955,6 @@
       "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==",
       "peer": true
     },
-    "prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4137,12 +3987,6 @@
         "object-assign": "^4.1.1",
         "scheduler": "^0.20.2"
       }
-    },
-    "react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "peer": true
     },
     "react-property": {
       "version": "2.0.0",
@@ -4261,16 +4105,6 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
-    },
-    "speech-rule-engine": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.0.7.tgz",
-      "integrity": "sha512-sJrL3/wHzNwJRLBdf6CjJWIlxC04iYKkyXvYSVsWVOiC2DSkHmxsqOhEeMsBA9XK+CHuNcsdkbFDnoUfAsmp9g==",
-      "requires": {
-        "commander": "9.2.0",
-        "wicked-good-xpath": "1.3.0",
-        "xmldom-sre": "0.1.31"
-      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -4413,21 +4247,11 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "peer": true
     },
-    "wicked-good-xpath": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
-      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw=="
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
-    },
-    "xmldom-sre": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom-sre/-/xmldom-sre-0.1.31.tgz",
-      "integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urbit/foundation-design-system",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@urbit/foundation-design-system",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,6 @@
     "gray-matter": "^4.0.3",
     "html-react-parser": "^1.4.14",
     "luxon": "^3.0.1",
-    "mathjax-full": "^3.2.2",
-    "mathjax-react": "^2.0.1",
     "prism-react-renderer": "^1.3.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "gray-matter": "^4.0.3",
     "html-react-parser": "^1.4.14",
     "luxon": "^3.0.1",
+    "mathjax-full": "^3.2.2",
+    "mathjax-react": "^2.0.1",
     "prism-react-renderer": "^1.3.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urbit/foundation-design-system",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "A system of design variables, Markdoc and React components intended for Urbit Foundation projects.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,12 +9,12 @@ export default [
     input: "src/index.js",
     output: [
       {
-        file: packageJson.main,
+        dir: packageJson.main.slice(0, -8),
         format: "cjs",
         sourcemap: false,
       },
       {
-        file: packageJson.module,
+        dir: packageJson.module.slice(0, -8),
         format: "esm",
         sourcemap: false,
       },

--- a/src/components/Markdown.js
+++ b/src/components/Markdown.js
@@ -1,10 +1,12 @@
 import React from "react";
 import Link from "next/link";
-import Markdoc, { Ast, Tag } from "@urbit/markdoc";
+import dynamic from "next/dynamic";
+import Markdoc, { Ast } from "@urbit/markdoc";
 import { heading } from "../schema/heading.markdoc.js";
 import { footnoteRef } from "../schema/footnoteRef.markdoc.js";
 import { footnoteItem } from "../schema/footnoteItem.markdoc.js";
 import { link } from "../schema/link.markdoc.js";
+import { math } from "../schema/math.markdoc.js";
 import { image } from "../schema/image.markdoc.js";
 import { sup } from "../schema/superscript.markdoc.js";
 import { fence } from "../schema/fence.markdoc";
@@ -21,6 +23,9 @@ import Callout from "./markdown/Callout";
 import Fence from "./markdown/Fence.js";
 import parse from "html-react-parser";
 
+const Math = dynamic(() => import("./markdown/Math"), {
+  ssr: false
+})
 const RenderHtml = ({ content }) => {
   return parse(content);
 };
@@ -73,6 +78,7 @@ export function MarkdownParse({ post }) {
       link,
       div,
       iframe,
+      math
     },
   });
 }
@@ -89,8 +95,9 @@ export function MarkdownRender({ content }) {
       NextLink,
       Div,
       Iframe,
+      Math
     },
-  });
+  })
 }
 
 const footnoteParse = (partialAst) => {

--- a/src/components/markdown/Math.js
+++ b/src/components/markdown/Math.js
@@ -8,7 +8,7 @@ export default function Math({ block = false, className = "", children }) {
         : exp?.props?.children
             ? exp.props.children
             : exp;
-    const classes = className + (block === true) ? "block text-center" : "";
+    const classes = className + (block === true ? "block text-center" : "");
 
     const [isReady, setIsReady] = React.useState(__MathJax_State__.isReady);
 

--- a/src/components/markdown/Math.js
+++ b/src/components/markdown/Math.js
@@ -2,7 +2,8 @@ import React from "react";
 import { MathComponent } from "mathjax-react"
 
 const Math = ({ block = false, children }) => {
-    const exp = children?.join ? children.map(e => e?.props?.children ? e.props.children : e).join("") : children
+    let exp = children?.join ? children.map(e => e?.props?.children ? e.props.children : e).join("") : children;
+    exp = exp?.props?.children ? exp.props.children.join("") : exp;
     return <MathComponent display={block} tex={String.raw`${exp}`} />;
 };
 

--- a/src/components/markdown/Math.js
+++ b/src/components/markdown/Math.js
@@ -2,7 +2,8 @@ import React from "react";
 import { MathComponent } from "mathjax-react"
 
 const Math = ({ block = false, children }) => {
-    return <MathComponent display={block} tex={String.raw`${children}`} />;
+    const exp = children?.join ? children.map(e => e?.props?.children ? e.props.children : e).join("") : children
+    return <MathComponent display={block} tex={String.raw`${exp}`} />;
 };
 
 export default Math;

--- a/src/components/markdown/Math.js
+++ b/src/components/markdown/Math.js
@@ -3,7 +3,11 @@ import { MathComponent } from "mathjax-react"
 
 const Math = ({ block = false, children }) => {
     let exp = children?.join ? children.map(e => e?.props?.children ? e.props.children : e).join("") : children;
-    exp = exp?.props?.children ? exp.props.children.join("") : exp;
+    exp = exp?.props?.children?.join
+        ? exp.props.children.join("\n")
+        : exp?.props?.children
+            ? exp.props.children
+            : exp;
     return <MathComponent display={block} tex={String.raw`${exp}`} />;
 };
 

--- a/src/components/markdown/Math.js
+++ b/src/components/markdown/Math.js
@@ -1,14 +1,42 @@
 import React from "react";
-import { MathComponent } from "mathjax-react"
 
-const Math = ({ block = false, children }) => {
+export default function Math({ block = false, className = "", children }) {
+    const rootElementRef = React.useRef(null);
     let exp = children?.join ? children.map(e => e?.props?.children ? e.props.children : e).join("") : children;
     exp = exp?.props?.children?.join
         ? exp.props.children.join("\n")
         : exp?.props?.children
             ? exp.props.children
             : exp;
-    return <MathComponent display={block} tex={String.raw`${exp}`} />;
-};
+    const classes = className + (block === true) ? "block text-center" : "";
 
-export default Math;
+    const [isReady, setIsReady] = React.useState(__MathJax_State__.isReady);
+
+    React.useLayoutEffect(() => {
+        if (!isReady) {
+            __MathJax_State__.promise.then(() => setIsReady(true));
+            return;
+        }
+
+        const mathElement = rootElementRef.current;
+
+        mathElement.innerHTML = "";
+
+        MathJax.texReset();
+
+        const options = MathJax.getMetricsFor(mathElement);
+        options.display = block;
+
+        MathJax.tex2chtmlPromise(String.raw`${exp}`, options)
+            .then(function (node) {
+                mathElement.appendChild(node);
+                MathJax.startup.document.clear();
+                MathJax.startup.document.updateDocument();
+            })
+            .catch(function (err) {
+                console.error(err);
+            });
+    }, [exp, block, isReady]);
+
+    return <span className={classes} ref={rootElementRef}></span>;
+}

--- a/src/components/markdown/Math.js
+++ b/src/components/markdown/Math.js
@@ -1,0 +1,8 @@
+import React from "react";
+import { MathComponent } from "mathjax-react"
+
+const Math = ({ block = false, children }) => {
+    return <MathComponent display={block} tex={String.raw`${children}`} />;
+};
+
+export default Math;

--- a/src/schema/math.markdoc.js
+++ b/src/schema/math.markdoc.js
@@ -1,0 +1,8 @@
+export const math = {
+    render: "Math",
+    attributes: {
+        block: {
+            type: Boolean,
+        },
+    },
+};

--- a/src/schema/math.markdoc.js
+++ b/src/schema/math.markdoc.js
@@ -4,5 +4,8 @@ export const math = {
         block: {
             type: Boolean,
         },
+        className: {
+            type: String
+        }
     },
 };


### PR DESCRIPTION
Adds the [mathjax-react](https://github.com/CharlieMcVicker/mathjax-react) package and a Math component to display equations. In context, you'd use `{% math %}` to wrap an equation with an optional `block` parameter when you want it to be a block, not inline.

Fixes #12 

Open questions:

- This requires `String.raw()` to parse strings without assuming we're using backslashes as escapes, or else obviously LaTeX doesn't work. We can't really selectively do this processing, as the first time we pass a string without `String.raw()`, it seems to escape the slashes. Are there consequences of enforcing `String.raw()` on every single call of our Markdown parser? (How often are we using backslash escapes in our writing anyway?) Basically I want to test some Markdown processing more before merging.
- Obviously the above would be a big breaking change necessitating a major version bump. But does this even meet our needs? @sigilante If you can present some examples of what you'd want processed, it would help assess suitability.

Thus far `\sum_{2}^{\longrightarrow \beta}\equiv \beta\beta\beta\beta` becomes, well,

<img width="324" alt="image" src="https://user-images.githubusercontent.com/20846414/190053111-a44da328-89f4-48c9-b766-a048f999ed7e.png">
