### PR TITLE
markdown: set unique ids for headers

### DIFF
--- a/src/schema/heading.markdoc.js
+++ b/src/schema/heading.markdoc.js
@@ -1,31 +1,5 @@
 import { Tag } from "@urbit/markdoc";
 
-function generateID(children, attributes) {
-  if (attributes.id && typeof attributes.id === "string") {
-    return attributes.id;
-  }
-
-  const getBottom = (parent) =>
-    parent?.children
-      ? getBottom(parent.children)
-      : parent[0]?.children
-      ? getBottom(parent[0].children)
-      : parent;
-
-  const bottomChildren = [
-    children
-      .map((child) => getBottom(child))
-      .flat()
-      .join(""),
-  ];
-  return bottomChildren
-    .filter((child) => typeof child === "string")
-    .join(" ")
-    .replace(/[=?!><:;,+#^|$&~"*@\.%/]/g, "")
-    .replace(/\s+/g, "-")
-    .toLowerCase();
-}
-
 export const heading = {
   children: ["inline"],
   attributes: {
@@ -36,11 +10,9 @@ export const heading = {
     const attributes = node.transformAttributes(config);
     const children = node.transformChildren(config);
 
-    const id = generateID(children, attributes);
-
     return new Tag(
       `h${node.attributes["level"]}`,
-      { ...attributes, id },
+      { ...attributes },
       children
     );
   },


### PR DESCRIPTION
Right now our headers don't distinguish themselves by ID when multiple headers sharing the same text are on the page, resulting in strange table of contents behaviour.

In this PR, we pull the ID generation logic out of the rendering step (which has no knowledge of previous headers when transforming nodes into content) and into the parsing step, keeping a map of our headers and then appending `-1` or `-2`, etc etc.

Fixes #16 