### PR TITLE
markdown.css: enforce table-width of 100%, break contents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urbit/foundation-design-system",
-  "version": "0.5.1",
+  "version": "0.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@urbit/foundation-design-system",
-      "version": "0.5.1",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urbit/foundation-design-system",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "A system of design variables, Markdoc and React components intended for Urbit Foundation projects.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/styles/markdown.css
+++ b/styles/markdown.css
@@ -162,6 +162,7 @@
 }
 
 .markdown table {
+  @apply table-fixed w-full;
   border-collapse: separate;
   border-spacing: 0;
   min-width: 350px;
@@ -174,6 +175,7 @@
   border-bottom-width: 2px;
   border-bottom-style: solid;
   padding: 8px !important;
+  overflow-wrap: break-word;
   @apply border-wall-100;
 }
 


### PR DESCRIPTION
Fixes urbit/developers.urbit.org#194

Enforces that tables use the full width but also lets their contents overflow and wrap. 

This means smaller tables now widen:

<img width="818" alt="image" src="https://user-images.githubusercontent.com/20846414/196310733-651c4506-333d-464a-a8b2-80e8ed601cce.png">

<img width="820" alt="image" src="https://user-images.githubusercontent.com/20846414/196310764-81cd3e99-63a9-45e1-a4d8-2e9b17226467.png">

And over-wide tables now wrap:

<img width="1150" alt="image" src="https://user-images.githubusercontent.com/20846414/196310836-8dc4feae-16e9-4256-b5d1-0caace5a484b.png">


<img width="798" alt="image" src="https://user-images.githubusercontent.com/20846414/196310807-bbd13890-500b-4226-b583-7421880878e9.png">
