### PR TITLE
in pages such as reference/glossary, next and previous are swapped be…

### DIFF
--- a/src/lib/lib.js
+++ b/src/lib/lib.js
@@ -100,6 +100,8 @@ export function getAllPosts(fields = [], key, sort = "") {
           : 1;
       } else if (sort === "weight") {
         return post1.weight > post2.weight ? -1 : 1;
+      } else if (sort === "alphanumeric") {
+        return post1.title > post2.title ? -1 : 1;
       }
     });
   return posts;


### PR DESCRIPTION
…cause there is no weight. Should be alphanumeric

Need to update urbit/developers.urbit.org ...slug pages to use sort = "alphanumeric" once this is published (I can do this next, if this solution works) in places where weight is not provided, such as Glossary. In these cases likely weight should not be used anyway because it will be a maintenance nightmare.

```
  const previousPost =
    getPreviousPost(
      params.slug?.slice(-1).join("") || "reference",
      ["title", "slug", "weight"],
      join("reference", params.slug?.slice(0, -1).join("/") || "/"),
      "alphanumeric" // See here
    ) || null;
```

cc @matildepark 

![Screen Shot 2022-12-04 at 2 56 20 PM](https://user-images.githubusercontent.com/1972316/205520617-c59bed4f-1582-4498-9e39-cdee2338a6fa.png)
